### PR TITLE
Use adapters for Mock configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ add the following to the dependencies in `mix.exs`
 {:ex_cell, "~> 0.0.2"}
 ```
 
-In Phoenix 1.3.0+ add the following to `lib/app_web/web.ex`
+In Phoenix 1.3.0+ add the following to `lib/app_web/web.ex`:
 
 ```ex
 
@@ -19,7 +19,7 @@ def controller do
   quote do
   ...
 
-  use ExCell.Controller, adapter: Phoenix.Controller
+  import ExCell.Controller
 
   ...
   end
@@ -37,8 +37,7 @@ end
 
 def cell(opts \\ []) do
   quote do
-    use ExCell.Cell, namespace: unquote(opts[:namespace]) || AppWeb,
-                     adapter: Phoenix.View
+    use ExCell.Cell, namespace: unquote(opts[:namespace]) || AppWeb
 
     use Phoenix.View, root: unquote(opts[:root]) || "lib/app_web/cells",
                       path: __MODULE__

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :ex_cell, ExCell, view_adapter: ExCell.MockViewAdapter,
+                         controller_adapter: ExCell.MockControllerAdapter,
+                         cell_adapter: ExCell.MockCellAdapter

--- a/lib/ex_cell/cell.ex
+++ b/lib/ex_cell/cell.ex
@@ -3,7 +3,6 @@ defmodule ExCell.Cell do
   Cell methods that can be overridden
   """
   alias Phoenix.HTML.Tag
-  alias ExCell.Cell
 
   @doc false
   def name(module, namespace) do
@@ -53,15 +52,14 @@ defmodule ExCell.Cell do
     quote do
       import ExCell.View
 
-      def name, do: apply(cell_adapter(), :name, [__MODULE__, unquote(opts[:namespace])])
+      def name do
+        cell_adapter().name(__MODULE__, unquote(opts[:namespace]))
+      end
 
       def class_name, do: name()
 
       def params, do: %{}
       def params(values), do: Map.merge(params(), values)
-
-      def view_adapter, do: unquote(opts[:adapter])
-      def cell_adapter, do: unquote(opts[:cell_adapter] || Cell)
 
       def container do
         container(%{}, [], [do: nil])
@@ -88,18 +86,15 @@ defmodule ExCell.Cell do
       end
 
       def container(%{} = params, options, [do: content]) when is_list(options) do
-        class_name = apply(
-          cell_adapter(),
-          :class_name,
-          [[class_name(), options[:class]]]
-        )
+        class_name = [class_name(), options[:class]]
+                     |> cell_adapter().class_name()
 
         options = Keyword.put(options, :class, class_name)
 
-        apply(cell_adapter(),
-              :container,
-              [name(), params(params), options, content])
+        cell_adapter().container(name(), params(params), options, content)
       end
+
+      defp cell_adapter, do: unquote(ExCell.config(:cell_adapter))
 
       defoverridable [name: 0, params: 0, class_name: 0]
     end

--- a/lib/ex_cell/controller.ex
+++ b/lib/ex_cell/controller.ex
@@ -4,20 +4,11 @@ defmodule ExCell.Controller do
   """
   alias ExCell.Controller
 
-  defmacro __using__(opts \\ []) do
-    quote do
-      def cell(conn, cell, assigns \\ []) do
-        Controller.cell(
-          unquote(opts[:adapter]),
-          conn,
-          cell,
-          assigns
-        )
-      end
-    end
+  defmacrop controller_adapter do
+    ExCell.config(:controller_adapter, Phoenix.Controller)
   end
 
-  def cell(adapter, conn, cell, assigns \\ []) do
-    adapter.render(conn, cell, "template.html", assigns)
+  def cell(conn, cell, assigns \\ []) do
+    controller_adapter().render(conn, cell, "template.html", assigns)
   end
 end

--- a/lib/ex_cell/ex_cell.ex
+++ b/lib/ex_cell/ex_cell.ex
@@ -9,7 +9,8 @@ defmodule ExCell do
   end
 
   def config(keyword, fallback \\ nil) do
-    Application.fetch_env!(:ex_cell, __MODULE__)
+    :ex_cell
+    |> Application.fetch_env!(__MODULE__)
     |> Keyword.get(keyword, fallback)
   end
 end

--- a/lib/ex_cell/ex_cell.ex
+++ b/lib/ex_cell/ex_cell.ex
@@ -7,4 +7,9 @@ defmodule ExCell do
     |> Module.split
     |> Kernel.--(Module.split(relative_to))
   end
+
+  def config(keyword, fallback \\ nil) do
+    Application.fetch_env!(:ex_cell, __MODULE__)
+    |> Keyword.get(keyword, fallback)
+  end
 end

--- a/lib/ex_cell/view.ex
+++ b/lib/ex_cell/view.ex
@@ -2,13 +2,7 @@ defmodule ExCell.View do
   @moduledoc """
   Cell helpers used to render the cells in both Views and Cells
   """
-  def relative_path(module, namespace) do
-    module
-    |> ExCell.module_relative_to(namespace)
-    |> Enum.map(&Macro.underscore/1)
-    |> Enum.join("/")
-    |> String.replace_suffix("_cell", "")
-  end
+  defmacrop view_adapter, do: ExCell.config(:view_adapter, Phoenix.View)
 
   def cell(cell) do
     render_cell(cell, [])
@@ -43,10 +37,10 @@ defmodule ExCell.View do
   end
 
   defp render_cell(cell, assigns) do
-    apply(cell.view_adapter, :render, [cell, "template.html", assigns])
+    view_adapter().render(cell, "template.html", assigns)
   end
 
   defp render_cell_to_string(cell, assigns) do
-    apply(cell.view_adapter, :render_to_string, [cell, "template.html", assigns])
+    view_adapter().render_to_string(cell, "template.html", assigns)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule ExCell.Mixfile do
      source_url: "https://github.com/defactosoftware/ex_cell",
      version: @version,
      elixir: "~> 1.2",
+     elixirc_paths: elixirc_paths(Mix.env),
      build_per_environment: false,
      description: description(),
      package: package(),
@@ -25,6 +26,9 @@ defmodule ExCell.Mixfile do
   Phoenix.
   """
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp package do
     [

--- a/test/ex_cell/cell_test.exs
+++ b/test/ex_cell/cell_test.exs
@@ -77,34 +77,16 @@ defmodule ExCell.CellTest do
   end
 
   describe "__using__" do
-    defmodule MockViewAdapter do
-      def render(cell, template, args), do: [cell, template, args]
-      def render_to_string(cell, template, args), do: [cell, template, args]
-    end
-
-    defmodule MockCellAdapter do
-      def name(module, namespace), do: Cell.name(module, namespace)
-      def class_name(classes), do: Cell.class_name(classes)
-      def container(name, params \\ %{}, options \\ [], content \\ nil) do
-        [name, params, options, content]
-      end
-    end
-
     defmodule MockCell do
-      use Cell, adapter: MockViewAdapter,
-                cell_adapter: MockCellAdapter,
-                namespace: ExCell.CellTest
+      use Cell, namespace: ExCell.CellTest
     end
 
     defmodule MockCellWithoutNamespace do
-      use Cell, adapter: MockViewAdapter,
-                cell_adapter: MockCellAdapter
+      use Cell
     end
 
     defmodule MockCellWithOverrideables do
-      use Cell, adapter: MockViewAdapter,
-                cell_adapter: MockCellAdapter,
-                namespace: ExCell.CellTest
+      use Cell, namespace: ExCell.CellTest
 
       def name do
         "HelloWorld"

--- a/test/ex_cell/controller_test.exs
+++ b/test/ex_cell/controller_test.exs
@@ -1,17 +1,11 @@
 defmodule ExCell.ControllerTest do
   use ExUnit.Case
 
-  defmodule MockController do
-    use ExCell.Controller, adapter: MockController
-
-    def render(conn, cell, template, args), do: [conn, cell, template, args]
-  end
-
   test "cell/2 with ExCell" do
-    assert MockController.cell(%{}, :mock_cell) === [%{}, :mock_cell, "template.html", []]
+    assert ExCell.Controller.cell(%{}, :mock_cell) === [%{}, :mock_cell, "template.html", []]
   end
 
   test "cell/3 with ExCell and arguments" do
-    assert MockController.cell(%{}, :mock_cell, []) === [%{}, :mock_cell, "template.html", []]
+    assert ExCell.Controller.cell(%{}, :mock_cell, []) === [%{}, :mock_cell, "template.html", []]
   end
 end

--- a/test/ex_cell/view_test.exs
+++ b/test/ex_cell/view_test.exs
@@ -1,14 +1,7 @@
 defmodule ExCell.ViewTest do
   use ExUnit.Case
   alias ExCell.View
-
-  defmodule MockViewAdapter do
-    @moduledoc """
-    Mock Phoenix View
-    """
-    def render(cell, template, args), do: [cell, template, args]
-    def render_to_string(cell, template, args), do: [cell, template, args]
-  end
+  alias ExCell.Test.MockViewAdapter
 
   defmodule MockCell do
     @moduledoc """

--- a/test/support/mock_cell_adapter.ex
+++ b/test/support/mock_cell_adapter.ex
@@ -1,0 +1,9 @@
+defmodule ExCell.MockCellAdapter do
+  alias ExCell.Cell
+
+  def name(module, namespace), do: Cell.name(module, namespace)
+  def class_name(classes), do: Cell.class_name(classes)
+  def container(name, params \\ %{}, options \\ [], content \\ nil) do
+    [name, params, options, content]
+  end
+end

--- a/test/support/mock_controller_adapter.ex
+++ b/test/support/mock_controller_adapter.ex
@@ -1,0 +1,4 @@
+defmodule ExCell.MockControllerAdapter do
+  def render(conn, cell, template, args \\ []), do: [conn, cell, template, args]
+  def render_to_string(conn, cell, template, args \\ []), do: [conn, cell, template, args]
+end

--- a/test/support/mock_view_adapter.ex
+++ b/test/support/mock_view_adapter.ex
@@ -1,0 +1,4 @@
+defmodule ExCell.MockViewAdapter do
+  def render(cell, template, args), do: [cell, template, args]
+  def render_to_string(cell, template, args), do: [cell, template, args]
+end


### PR DESCRIPTION
- Adapters are now configured in a mix config
- Adapters have a default fallback to Phoenix
- Adapters don't have to be configured by the user
- Adapters are now configured on _compile time_, slightly decreases unneeded overhead

Got rid of a bit of macro magic.