### PR TITLE
Allow the attribute name to be overriden and prefixed

### DIFF
--- a/lib/ex_cell/base.ex
+++ b/lib/ex_cell/base.ex
@@ -157,7 +157,7 @@ defmodule ExCell.Base do
       def container(%{} = params, options, [do: content]) when is_list(options), do:
         do_container(params, options, content)
 
-      def do_container(params \\ {}, options \\ [], content \\ nil) do
+      defp do_container(params, options, content) do
         {tag, options} = Keyword.pop(options, :tag, :div)
 
         attributes = attributes(

--- a/lib/ex_cell/base.ex
+++ b/lib/ex_cell/base.ex
@@ -2,12 +2,45 @@ defmodule ExCell.Base do
   @moduledoc false
   alias Phoenix.HTML.Tag
 
+  @dialyzer [{:no_match, relative_name: 2}]
+
+  def relative_name(module, namespace) do
+    parts = case namespace do
+      nil -> Module.split(module)
+      _ -> ExCell.module_relative_to(module, namespace)
+    end
+
+    Enum.join(parts, "-")
+  end
+
+  def attributes(attribute_name, class_name, options, params) do
+    {data, options} = Keyword.pop(options, :data)
+    {class, options} = Keyword.pop(options, :class)
+
+    options
+    |> Keyword.put(:data, data_attribute(attribute_name, data, params))
+    |> Keyword.put(:class, class_attribute(class_name, class))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  def data_attribute(name, data, params \\ %{}) do
+    (data || [])
+    |> Enum.concat([cell: name, cell_params: Poison.encode!(params)])
+  end
+
+  def class_attribute(name, class) do
+    [name, class]
+    |> List.flatten
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
+  end
+
   defmacro __using__(opts \\ []) do
     quote do
       import ExCell.View
+      import ExCell.Base
 
       @namespace unquote(opts[:namespace])
-      @dialyzer [{:no_match, relative_name: 2}]
 
       @doc """
       Returns the name of the module as a string. Module namespaces are replaced
@@ -48,6 +81,19 @@ defmodule ExCell.Base do
 
       @doc false
       def params, do: %{}
+
+      @doc """
+      Combines the parameters set on the cell with custom parameters for a
+      specific instance
+
+      ## Examples
+
+          iex(0)> AvatarCell.params
+          %{hello: "world"}
+          iex(0)> AvatarCell.params(%{foo: "bar"})
+          %{hello: "world", foo: "bar"}
+      """
+      def params(values), do: Map.merge(params(), values)
 
       @doc """
       Returns the container of a cell as a Phoenix.Tag.
@@ -98,61 +144,29 @@ defmodule ExCell.Base do
           iex(1)> safe_to_string(AvatarCell.container(%{ foo: "bar" }))
           "<a class=\\"AvatarCell\\" data-cell=\\"AvatarCell\\" data-cell-params=\\"{&quot;foo&quot;:&quot;bar&quot;}">"
       """
-      def container(%{} = params), do: container(params, [], [do: nil])
-      def container(%{} = params, [do: content]), do: container(params, [], [do: content])
-      def container(%{} = params, options) when is_list(options), do: container(params, options, [do: nil])
-      def container(%{} = params, options, [do: content]) when is_list(options), do: do_container(params, options, content)
+      def container(%{} = params), do:
+        container(params, [], [do: nil])
+      def container(%{} = params, [do: content]), do:
+        container(params, [], [do: content])
+      def container(%{} = params, options) when is_list(options), do:
+        container(params, options, [do: nil])
+      def container(%{} = params, options, [do: content]) when is_list(options), do:
+        do_container(params, options, content)
 
-      @doc """
-      Combines the parameters set on the cell with custom parameters for a specific instance
-
-      ## Examples
-
-          iex(0)> AvatarCell.params
-          %{hello: "world"}
-          iex(0)> AvatarCell.params(%{foo: "bar"})
-          %{hello: "world", foo: "bar"}
-      """
-      def params(values), do: Map.merge(params(), values)
-
-      defp relative_name(module, namespace) do
-        parts = case namespace do
-          nil -> Module.split(module)
-          _ -> ExCell.module_relative_to(module, namespace)
-        end
-
-        Enum.join(parts, "-")
-      end
-
-      defp do_container(params \\ %{}, options \\ [], content \\ nil) do
+      def do_container(params \\ {}, options \\ [], content \\ nil) do
         {tag, options} = Keyword.pop(options, :tag, :div)
 
-        class_name = [class_name()] ++ [options[:class]]
-                     |> List.flatten
-                     |> Enum.reject(&is_nil/1)
-                     |> Enum.join(" ")
-
-        options = Keyword.put(options, :class, class_name)
-
-        attributes = attributes(attribute_name(), options, params(params))
+        attributes = attributes(
+          attribute_name(),
+          class_name(),
+          options,
+          params(params)
+        )
 
         case content do
           nil -> Tag.tag(tag, attributes)
           _ -> Tag.content_tag(tag, content, attributes)
         end
-      end
-
-      defp attributes(name, options, params) do
-        {data, options} = Keyword.pop(options, :data)
-
-        data = Enum.concat(
-          (data || []),
-          [cell: name, cell_params: Poison.encode!(params)]
-        )
-
-        options
-        |> Keyword.put(:data, data)
-        |> Enum.reject(&is_nil/1)
       end
 
       defoverridable [class_name: 0, attribute_name: 0, params: 0]

--- a/lib/ex_cell/base.ex
+++ b/lib/ex_cell/base.ex
@@ -24,7 +24,9 @@ defmodule ExCell.Base do
       def name, do: relative_name(__MODULE__, @namespace)
 
       @doc """
-      Generates a CSS class name based on the cell name
+      Generates the CSS class name based on the cell name. Can be overriden
+      to pre- or postfix the class name or to create a distinct class name with
+      CSS modules.
 
       ## Examples
 
@@ -32,6 +34,17 @@ defmodule ExCell.Base do
           "AvatarCell"
       """
       def class_name, do: name()
+
+      @doc """
+      Generates the HTML attribute name based on the cell name. Can be overriden
+      to pre- or postfix the attribute name.
+
+      ## Examples
+
+          iex(0)> AvatarCell.attribute_name()
+          "AvatarCell"
+      """
+      def attribute_name, do: name()
 
       @doc false
       def params, do: %{}
@@ -121,7 +134,7 @@ defmodule ExCell.Base do
 
         options = Keyword.put(options, :class, class_name)
 
-        attributes = attributes(name(), options, params(params))
+        attributes = attributes(attribute_name(), options, params(params))
 
         case content do
           nil -> Tag.tag(tag, attributes)
@@ -142,7 +155,7 @@ defmodule ExCell.Base do
         |> Enum.reject(&is_nil/1)
       end
 
-      defoverridable [class_name: 0, params: 0]
+      defoverridable [class_name: 0, attribute_name: 0, params: 0]
     end
   end
 end

--- a/lib/ex_cell/base.ex
+++ b/lib/ex_cell/base.ex
@@ -23,9 +23,13 @@ defmodule ExCell.Base do
     |> Enum.reject(&is_nil/1)
   end
 
-  def data_attribute(name, data, params \\ %{}) do
-    (data || [])
-    |> Enum.concat([cell: name, cell_params: Poison.encode!(params)])
+  def data_attribute(name, data \\ [], params \\ %{})
+  def data_attribute(name, data, params) when is_nil(data), do:
+    data_attribute(name, [], params)
+
+  def data_attribute(name, data, params) when is_list(data) do
+    data
+    |> Keyword.merge([cell: name, cell_params: Poison.encode!(params)])
   end
 
   def class_attribute(name, class) do

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule ExCell.Mixfile do
      package: package(),
      deps: deps(),
      test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: [coveralls: :test],
+     preferred_cli_env: [coveralls: :test, "coveralls.detail": :test],
      dialyzer: [plt_add_deps: true]]
   end
 

--- a/test/ex_cell/base_test.exs
+++ b/test/ex_cell/base_test.exs
@@ -1,0 +1,73 @@
+defmodule ExCell.BaseTest do
+  use ExUnit.Case
+
+  alias ExCell.Base
+
+  describe "relative_name/2" do
+    test "returns the module name" do
+      assert Base.relative_name(MockCell, nil) == "MockCell"
+    end
+
+    test "returns the relative module name" do
+      assert Base.relative_name(Bar.MockCell, Bar) == "MockCell"
+    end
+
+    test "returns the relative module name with dashes for nested cells" do
+      assert Base.relative_name(Bar.MockCell, nil) == "Bar-MockCell"
+    end
+  end
+
+  describe "attributes/4" do
+    test "it rejects nil values" do
+      assert Base.attributes(nil, nil, [], %{}) ==
+        [class: "", data: [cell: nil, cell_params: "{}"]]
+    end
+
+    test "it sets the data attribute" do
+      assert Base.attributes(nil, nil, [data: [foo: "bar"]], %{}) ==
+        [class: "", data: [foo: "bar", cell: nil, cell_params: "{}"]]
+    end
+
+    test "it sets the class attribute" do
+      assert Base.attributes(nil, nil, [class: "foo"], %{}) ==
+        [class: "foo", data: [cell: nil, cell_params: "{}"]]
+    end
+  end
+
+  describe "data_attribute/3" do
+    test "it defaults data to a list" do
+      assert Base.data_attribute(nil, nil, %{}) == [cell: nil, cell_params: "{}"]
+    end
+
+    test "it sets the cell name" do
+      assert Base.data_attribute("Hello", nil, %{}) ==
+        [cell: "Hello", cell_params: "{}"]
+    end
+
+    test "it encodes params" do
+      assert Base.data_attribute(nil, nil, %{foo: "Bar"}) ==
+        [cell: nil, cell_params: "{\"foo\":\"Bar\"}"]
+    end
+
+    test "it adds data attributes" do
+      assert Base.data_attribute(nil, [foo: "Bar"], %{}) ==
+        [foo: "Bar", cell: nil, cell_params: "{}"]
+    end
+  end
+
+  describe "class_attribute/2" do
+    test "adds the name" do
+      assert Base.class_attribute("Hello", "World") ==
+        "Hello World"
+    end
+
+    test "allows lists" do
+      assert Base.class_attribute(["Hello", "World"], ["Foo", "Bar"]) ==
+        "Hello World Foo Bar"
+    end
+
+    test "rejects nil" do
+      assert Base.class_attribute(nil, nil) == ""
+    end
+  end
+end

--- a/test/ex_cell/base_test.exs
+++ b/test/ex_cell/base_test.exs
@@ -35,6 +35,10 @@ defmodule ExCell.BaseTest do
   end
 
   describe "data_attribute/3" do
+    test "it defaults" do
+      assert Base.data_attribute(nil) == [cell: nil, cell_params: "{}"]
+    end
+
     test "it defaults data to a list" do
       assert Base.data_attribute(nil, nil, %{}) == [cell: nil, cell_params: "{}"]
     end

--- a/test/ex_cell/cell_test.exs
+++ b/test/ex_cell/cell_test.exs
@@ -17,7 +17,8 @@ defmodule ExCell.CellTest do
     use Cell, namespace: Foo
 
     def params, do: %{foo: "Bar"}
-    def class_name, do: "FooBar"
+    def class_name, do: "Bar-" <> name()
+    def attribute_name, do: "World-" <> name()
   end
 
   alias Foo.Bar
@@ -38,6 +39,11 @@ defmodule ExCell.CellTest do
     test "defaults to a :div as tag" do
       assert safe_to_string(MockCell.container())
         == "<div class=\"MockCell\" data-cell=\"MockCell\" data-cell-params=\"{}\">"
+    end
+
+    test "overrideables" do
+      assert safe_to_string(MockCellWithOverridables.container())
+        == "<div class=\"Bar-MockCellWithOverridables\" data-cell=\"World-MockCellWithOverridables\" data-cell-params=\"{&quot;foo&quot;:&quot;Bar&quot;}\">"
     end
 
     test "custom tag" do
@@ -81,7 +87,17 @@ defmodule ExCell.CellTest do
     end
 
     test "class_name() is overrideable" do
-      assert MockCellWithOverridables.class_name == "FooBar"
+      assert MockCellWithOverridables.class_name == "Bar-MockCellWithOverridables"
+    end
+  end
+
+  describe "attribute_name/0" do
+    test "attribute_name()" do
+      assert MockCell.attribute_name == "MockCell"
+    end
+
+    test "attribute_name() is overrideable" do
+      assert MockCellWithOverridables.attribute_name == "World-MockCellWithOverridables"
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/DefactoSoftware/detroit/issues/515:

Because some applications (for example umbrella applications) define multiple cells, we need to have a way to prefix the cell attribute to avoid conflicting cell names for javascript initialisation.