### PR TITLE
Fallback nil data to a list

### DIFF
--- a/lib/ex_cell/adapters/cell_js.ex
+++ b/lib/ex_cell/adapters/cell_js.ex
@@ -49,7 +49,7 @@ defmodule ExCell.Adapters.CellJS do
   """
   def data_attribute(name, id, data \\ [], params \\ %{}), do:
     Keyword.merge(
-      data,
+      data || [],
       cell: name,
       cell_id: id,
       cell_params: Poison.encode!(params)

--- a/test/ex_cell/adapters/cell_js_test.exs
+++ b/test/ex_cell/adapters/cell_js_test.exs
@@ -24,12 +24,13 @@ defmodule ExCell.Adapters.CellJSTest do
   end
 
   describe "data_attribute/3" do
-    test "it defaults" do
-      assert CellJS.data_attribute(nil, nil) == [cell: nil, cell_id: nil, cell_params: "{}"]
-    end
-
     test "it defaults data to a list" do
       assert CellJS.data_attribute(nil, nil) ==
+        [cell: nil, cell_id: nil, cell_params: "{}"]
+    end
+
+    test "it defaults nil data to a list" do
+      assert CellJS.data_attribute(nil, nil, nil) ==
         [cell: nil, cell_id: nil, cell_params: "{}"]
     end
 


### PR DESCRIPTION
Closes #38

Alternatively we could do:

```ex
def data_attribute(name, id, data \\ [], params \\ %{})
def data_attribute(name, id, nil, params), do: data_attribute(name, id, [], params)
def data_attribute(name, id, data, params), do:
  Keyword.merge(
    data,
    cell: name,
    cell_id: id,
    cell_params: Poison.encode!(params)
  )
```

But this feels rather complex.